### PR TITLE
fix #144 : Make Maze2D.pointInBounds() check lower bounds too.

### DIFF
--- a/hipster-core/src/main/java/es/usc/citius/hipster/util/examples/maze/Maze2D.java
+++ b/hipster-core/src/main/java/es/usc/citius/hipster/util/examples/maze/Maze2D.java
@@ -371,7 +371,7 @@ public class Maze2D {
      * @return true if the point is in the maze.
      */
     public boolean pointInBounds(Point loc) {
-        return loc.x < this.columns && loc.y < this.rows;
+        return loc.x >= 0 && loc.x < this.columns && loc.y >= 0 && loc.y < this.rows;
     }
 
     /**

--- a/hipster-core/src/test/java/es/usc/citius/lab/hipster/maze/Maze2DTest.java
+++ b/hipster-core/src/test/java/es/usc/citius/lab/hipster/maze/Maze2DTest.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class Maze2DTest {
 
@@ -132,5 +133,22 @@ public class Maze2DTest {
         maze.removeObstacleRectangle(new Point(10, 1), new Point(17, 3));
         assertTrue(maze.diff(new Maze2D(refMaze)).isEmpty());
         assertTrue(!maze.diff(goal).isEmpty());
+    }
+    
+	@Test
+    public void testPointInBounds() {
+    	Maze2D maze = new Maze2D(testMaze);
+    	assertFalse(maze.pointInBounds(new Point(-1,0)));
+    	assertFalse(maze.pointInBounds(new Point(0,-1)));
+    	
+    	int colLength = maze.getMaze()[0].length;
+    	int rowLength = maze.getMaze().length;
+    	assertFalse(maze.pointInBounds(new Point(colLength,0)));
+    	assertFalse(maze.pointInBounds(new Point(0,rowLength)));
+    	
+    	assertTrue(maze.pointInBounds(new Point(0,0)));
+    	assertTrue(maze.pointInBounds(new Point(0,0)));
+    	assertTrue(maze.pointInBounds(new Point(colLength-1,0)));
+    	assertTrue(maze.pointInBounds(new Point(0,rowLength-1)));
     }
 }


### PR DESCRIPTION
Fixed issue 144.

The method pointInBounds() now checks that a point is within lower bounds.

Tests have been included to validate the result when a point is outside and inside of the bounds.