### PR TITLE
fix #146 : Update .gitignore to include Eclipse specific files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ nb-configuration.xml
 # Idea specific #
 *.iml
 .idea
+
+# Eclipse specific #
+.metadata/
+


### PR DESCRIPTION
Added Eclipse editor specific files to .gitignore.