### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/hipster-all/pom.xml
+++ b/hipster-all/pom.xml
@@ -31,21 +31,9 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>es.usc.citius.hipster</groupId>
-            <artifactId>hipster-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>es.usc.citius.hipster</groupId>
-            <artifactId>hipster-examples</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>es.usc.citius.hipster</groupId>
-            <artifactId>hipster-test</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+        
+        
+        
     </dependencies>
 
     <build>

--- a/hipster-examples/pom.xml
+++ b/hipster-examples/pom.xml
@@ -36,11 +36,7 @@
             <artifactId>hipster-core</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>es.usc.citius.hipster</groupId>
-            <artifactId>hipster-third-party-graphs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+        
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>

--- a/hipster-extensions/pom.xml
+++ b/hipster-extensions/pom.xml
@@ -21,22 +21,14 @@
             <artifactId>hipster-core</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>es.usc.citius.hipster</groupId>
-            <artifactId>hipster-third-party-graphs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+        
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>29.0-jre</version>
         </dependency>
         <!-- Using Guava annotations require this dependency-->
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <version>3.0.0</version>
-        </dependency>
+        
 
     </dependencies>
 

--- a/hipster-third-party-graphs/pom.xml
+++ b/hipster-third-party-graphs/pom.xml
@@ -43,20 +43,8 @@
             <artifactId>hipster-core</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>net.sf.jung</groupId>
-            <artifactId>jung-graph-impl</artifactId>
-            <version>2.0.1</version>
-        </dependency>
-        <dependency>
-            <groupId>net.sf.jung</groupId>
-            <artifactId>jung-algorithms</artifactId>
-            <version>2.0.1</version>
-        </dependency>
-        <dependency>
-            <groupId>net.sf.jung</groupId>
-            <artifactId>jung-io</artifactId>
-            <version>2.0.1</version>
-        </dependency>
+        
+        
+        
     </dependencies>
 </project>


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
hipster-pom
hipster-core
hipster-third-party-graphs
{groupId='net.sf.jung', artifactId='jung-graph-impl'}
{groupId='net.sf.jung', artifactId='jung-algorithms'}
{groupId='net.sf.jung', artifactId='jung-io'}
hipster-examples
{groupId='es.usc.citius.hipster', artifactId='hipster-third-party-graphs'}
hipster-test
hipster-all
{groupId='es.usc.citius.hipster', artifactId='hipster-core'}
{groupId='es.usc.citius.hipster', artifactId='hipster-examples'}
{groupId='es.usc.citius.hipster', artifactId='hipster-test'}
{groupId='junit', artifactId='junit'}
hipster-extensions
{groupId='es.usc.citius.hipster', artifactId='hipster-third-party-graphs'}
{groupId='com.google.code.findbugs', artifactId='jsr305'}


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
